### PR TITLE
Settings: Fix wrong icon definition

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -478,7 +478,7 @@ public class SettingsActivity extends SettingsBaseActivity
 
     @Override
     public void setTaskDescription(ActivityManager.TaskDescription taskDescription) {
-        taskDescription.setIcon(R.mipmap.ic_launcher);
+        taskDescription.setIcon(R.drawable.ic_launcher);
         super.setTaskDescription(taskDescription);
     }
 

--- a/src/com/android/settings/network/telephony/Enhanced4gLteSliceHelper.java
+++ b/src/com/android/settings/network/telephony/Enhanced4gLteSliceHelper.java
@@ -165,7 +165,7 @@ public class Enhanced4gLteSliceHelper {
      */
     private Slice getEnhanced4gLteSlice(Uri sliceUri, boolean isEnhanced4gLteEnabled, int subId) {
         final IconCompat icon = IconCompat.createWithResource(mContext,
-                R.mipmap.ic_launcher);
+                R.drawable.ic_launcher);
 
         return new ListBuilder(mContext, sliceUri, ListBuilder.INFINITY)
                 .setAccentColor(Utils.getColorAccentDefaultColor(mContext))

--- a/src/com/android/settings/shortcut/CreateShortcutPreferenceController.java
+++ b/src/com/android/settings/shortcut/CreateShortcutPreferenceController.java
@@ -149,7 +149,7 @@ public class CreateShortcutPreferenceController extends BasePreferenceController
             intent = new Intent();
         }
         intent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE,
-                Intent.ShortcutIconResource.fromContext(mContext, R.mipmap.ic_launcher))
+                Intent.ShortcutIconResource.fromContext(mContext, R.drawable.ic_launcher))
                 .putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent)
                 .putExtra(Intent.EXTRA_SHORTCUT_NAME, label);
 
@@ -220,7 +220,7 @@ public class CreateShortcutPreferenceController extends BasePreferenceController
                     R.layout.shortcut_badge_maskable,
                     context.getResources().getDimensionPixelSize(R.dimen.shortcut_size_maskable)));
         } else {
-            maskableIcon = Icon.createWithResource(context, R.mipmap.ic_launcher);
+            maskableIcon = Icon.createWithResource(context, R.drawable.ic_launcher);
         }
         final String shortcutId = SHORTCUT_ID_PREFIX +
                 shortcutIntent.getComponent().flattenToShortString();
@@ -252,7 +252,7 @@ public class CreateShortcutPreferenceController extends BasePreferenceController
             ((ImageView) view.findViewById(android.R.id.icon)).setImageDrawable(iconDrawable);
         } catch (PackageManager.NameNotFoundException e) {
             Log.w(TAG, "Cannot load icon from app " + app + ", returning a default icon");
-            Icon icon = Icon.createWithResource(context, R.mipmap.ic_launcher);
+            Icon icon = Icon.createWithResource(context, R.drawable.ic_launcher);
             ((ImageView) view.findViewById(android.R.id.icon)).setImageIcon(icon);
         }
 


### PR DESCRIPTION
packages/apps/Settings/src/com/android/settings/SettingsActivity.java:481: 错误: 找不到符号
        taskDescription.setIcon(R.mipmap.ic_launcher);
                                        ^
  符号:   变量 ic_launcher
  位置: 类 mipmap
packages/apps/Settings/src/com/android/settings/network/telephony/Enhanced4gLteSliceHelper.java:168: 错误: 找不到符号
                R.mipmap.ic_launcher);
                        ^
  符号:   变量 ic_launcher
  位置: 类 mipmap
packages/apps/Settings/src/com/android/settings/shortcut/CreateShortcutPreferenceController.java:152: 错误: 找不到符号
                Intent.ShortcutIconResource.fromContext(mContext, R.mipmap.ic_launcher))
                                                                          ^
  符号:   变量 ic_launcher
  位置: 类 mipmap
packages/apps/Settings/src/com/android/settings/shortcut/CreateShortcutPreferenceController.java:223: 错误: 找不到符号
            maskableIcon = Icon.createWithResource(context, R.mipmap.ic_launcher);
                                                                    ^
  符号:   变量 ic_launcher
  位置: 类 mipmap
packages/apps/Settings/src/com/android/settings/shortcut/CreateShortcutPreferenceController.java:255: 错误: 找不到符号
            Icon icon = Icon.createWithResource(context, R.mipmap.ic_launcher);
                                                                 ^
  符号:   变量 ic_launcher
  位置: 类 mipmap

Fix commit: d4176ef284171df51a4689174b