### PR TITLE
Settings: add a SwitchPreference to enable/disable screenshot sound

### DIFF
--- a/res/values-zh-rCN/exthm_strings.xml
+++ b/res/values-zh-rCN/exthm_strings.xml
@@ -22,6 +22,8 @@
     <string name="show_app_volume_title">分应用音量控制</string>
     <string name="show_app_volume_summary">在音量控制面板中显示应用程序的音量</string>
 
+    <string name="screenshot_sound_title">截屏声音</string>
+
     <!-- App lock -->
     <string name="applock_title">应用锁</string>
     <string name="applock_locked">已锁定</string>

--- a/res/values/exthm_strings.xml
+++ b/res/values/exthm_strings.xml
@@ -22,6 +22,8 @@
     <string name="show_app_volume_title">Show app volume</string>
     <string name="show_app_volume_summary">Show app volume in volume panel.</string>
 
+    <string name="screenshot_sound_title">Screenshot sound</string>
+
     <!-- App lock -->
     <string name="applock_title">App locker</string>
     <string name="applock_locked">Locked</string>

--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -187,6 +187,12 @@
           android:key="screen_locking_sounds"
           android:title="@string/screen_locking_sounds_title"/>
 
+        <!-- Screenshot sound -->
+        <org.exthmui.settings.preferences.SystemSettingSwitchPreference
+            android:key="screenshot_sound"
+            android:title="@string/screenshot_sound_title"
+            android:defaultValue="true" />
+
         <!-- Charging sounds -->
         <SwitchPreference
           android:key="charging_sounds"


### PR DESCRIPTION
According to https://github.com/exthmui/android_frameworks_base/commit/96667f6b46c1bae3b5ca7766ed99dce280f728f9 ,
there is already a screenshot sound setting here. But users can not control it.
This commit adds a SwitchPreference for it.